### PR TITLE
api.py: codespell Transfering -> Transferring

### DIFF
--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -423,7 +423,7 @@ class APIRequest(object):
         else:
             mode = "wb"
 
-        self.log("Transfering %s into %s" %
+        self.log("Transferring %s into %s" %
                  (self._bytename(size - existing_size), path))
         self.log("From %s" % (url, ))
 


### PR DESCRIPTION
codespell also wanted to do this, but it's the British spelling, so I skipped it.

```
README.md:30: catalogue  ==> catalog
```