### PR TITLE
added env ECMWF_API_RC_FILE to let user define the path of the config file

### DIFF
--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -43,7 +43,7 @@ except ImportError:
 
 
 ###############################################################################
-VERSION = '1.5.4'
+VERSION = '1.5.5'
 
 ###############################################################################
 
@@ -63,7 +63,10 @@ def _get_apikey_from_environ():
 
 
 def _get_apikey_from_rcfile():
-    rc = os.path.normpath(os.path.expanduser("~/.ecmwfapirc"))
+    if "ECMWF_API_RC_FILE" in os.environ:
+        rc = os.path.normpath(os.path.expanduser(os.environ["ECMWF_API_RC_FILE"]))
+    else:
+        rc = os.path.normpath(os.path.expanduser("~/.ecmwfapirc"))
 
     try:
         with open(rc) as f:


### PR DESCRIPTION
If the user has ECMWF_API_RC_FILE exported, the system will use this path. Otherwise it will use the default ~/.ecmwfapirc