### PR TITLE
Make get_apikey_values aligned with docstring

### DIFF
--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -106,17 +106,8 @@ def get_apikey_values():
     try:
         key_values = _get_apikey_from_environ()
     except APIKeyFetchError:
-        try:
-            key_values = _get_apikey_from_rcfile()
-        except APIKeyFetchError:
-            return (
-                os.environ.get("ECMWF_API_KEY", "anonymous"),
-                os.environ.get("ECMWF_API_URL", "https://api.ecmwf.int/v1"),
-                os.environ.get("ECMWF_API_EMAIL", "anonymous@ecmwf.int"),
-            )
-
+        key_values = _get_apikey_from_rcfile()
     return key_values
-
 
 ###############################################################################
 


### PR DESCRIPTION
The `get_apikey_values` function shows in my opinion some unexpected behavior, where it will never raise an `APIKeyFetchError`.  If it fails to load credentials from either env variables or from the rc file it will return some bogus credentials. In my opinion this is easier and to the point. If the key can not be returned from the env variables, it will try the rc file. If this is also not found an APIKeyFetchError will be raised. Otherwise the correct key is returned.