### PR TITLE
Add support for using Python's logging module instead of print statements

### DIFF
--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -260,8 +260,7 @@ class Connection(object):
         url = urljoin(self.url, url)
 
         if self.verbose:
-            self.log('Method %s' % method)
-            self.log('URL %s' % url)
+            self.log("Calling method %s on %s" % (method, url))
 
         headers = {
             "Accept": "application/json",
@@ -308,10 +307,10 @@ class Connection(object):
             self.location = urljoin(url, res.headers.get("Location", self.location))
 
         if self.verbose:
-            self.log("Code %s" % code)
-            self.log("Content-Type %s" % res.headers.get("Content-Type"))
-            self.log("Content-Length %s" % res.headers.get("Content-Length"))
-            self.log("Location %s" % res.headers.get("Location"))
+            self.log("Response code: %s" % code)
+            self.log("Response Content-Type: %s" % res.headers.get("Content-Type"))
+            self.log("Response Content-Length: %s" % res.headers.get("Content-Length"))
+            self.log("Response Location: %s" % res.headers.get("Location"))
 
         body = res.read().decode("utf-8")
         res.close()
@@ -327,7 +326,7 @@ class Connection(object):
                 error = True
 
         if self.verbose:
-            self.log(json.dumps(self.last, indent=4))
+            self.log("Response content: %s" % json.dumps(self.last, indent=4))
 
         self.status = self.last.get("status", self.status)
 

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -181,25 +181,10 @@ def get_api_url(url):
     )
 
 
-SAY = True
-
-
 class Ignore303(HTTPRedirectHandler):
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         if code in [301, 302]:
             # We want the posts to work even if we are redirected
-            if code == 301:
-                global SAY
-                if SAY:
-                    oldurl = req.get_full_url()
-                    print()
-                    print("*** ECMWF API has moved")
-                    print("***   OLD: %s" % get_api_url(oldurl))
-                    print("***   NEW: %s" % get_api_url(newurl))
-                    print("*** Please update your ~/.ecmwfapirc file")
-                    print()
-                    SAY = False
-
             try:
                 # Python < 3.4
                 data = req.get_data()

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -398,19 +398,22 @@ class APIRequest(object):
         self.quiet = quiet
         self.verbose = verbose
         self._empty_line = False
+
         self.log("ECMWF API python library %s" % (VERSION,))
         self.log("ECMWF API at %s" % (self.url,))
+
         user = self.connection.call("%s/%s" % (self.url, "who-am-i"))
 
         if os.environ.get("GITHUB_ACTION") is None:
             self.log("Welcome %s" % (user["full_name"] or "user '%s'" % user["uid"],))
 
-        info = self.connection.call("%s/%s" % (self.url, "info")).get("info")
-        self.show_info(info, user["uid"])
-        info = self.connection.call("%s/%s/%s" % (self.url, self.service, "info")).get(
-            "info"
-        )
-        self.show_info(info, user["uid"])
+        general_info = self.connection.call("%s/%s" % (self.url, "info")).get("info")
+        self.show_info(general_info, user["uid"])
+
+        service_specific_info = self.connection.call(
+            "%s/%s/%s" % (self.url, self.service, "info")
+        ).get("info")
+        self.show_info(service_specific_info, user["uid"])
 
         if news:
             try:

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -141,35 +141,35 @@ def robust(func):
                 return func(self, *args, **kwargs)
             except HTTPError as e:
                 if self.verbose:
-                    print("WARNING: HTTPError received %s" % (e))
+                    self.log("WARNING: HTTPError received %s" % e)
                 if e.code < 500 or e.code in (501,):  # 501: not implemented
                     raise
                 last_error = e
             except BadStatusLine as e:
                 if self.verbose:
-                    print("WARNING: BadStatusLine received %s" % (e))
+                    self.log("WARNING: BadStatusLine received %s" % e)
                 last_error = e
             except URLError as e:
                 if self.verbose:
-                    print("WARNING: URLError received %s %s" % (e.errno, e))
+                    self.log("WARNING: URLError received %s %s" % (e.errno, e))
                 last_error = e
             except APIException:
                 raise
             except RetryError as e:
                 if self.verbose:
-                    print("WARNING: HTTP received %s" % (e.code))
-                    print(e.text)
+                    self.log("WARNING: HTTP received %s" % e.code)
+                    self.log(e.text)
                 last_error = e
             except:
                 if self.verbose:
-                    print("Unexpected error:", sys.exc_info()[0])
-                    print(traceback.format_exc())
+                    self.log("Unexpected error: %s" % sys.exc_info()[0])
+                    self.log(traceback.format_exc())
                 raise
-            print("Error contacting the WebAPI, retrying in %d seconds ..." % delay)
+            self.log("Error contacting the WebAPI, retrying in %d seconds ..." % delay)
             time.sleep(delay)
             tries -= 1
         # if all retries have been exhausted, raise the last exception caught
-        print("Could not contact the WebAPI after %d tries, failing !" % max_tries)
+        self.log("Could not contact the WebAPI after %d tries, failing !" % max_tries)
         raise last_error
 
     return wrapped

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -41,8 +41,7 @@ except ImportError:
 try:
     import ssl
 except ImportError:
-    print("Python socket module was not compiled with SSL support. Aborting...")
-    sys.exit(1)
+    sys.exit("Python socket module was not compiled with SSL support. Aborting...")
 
 
 VERSION = "1.6.1"

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -182,6 +182,12 @@ def get_api_url(url):
 
 
 class Ignore303(HTTPRedirectHandler):
+
+    """Handler to automatically follow redirects.
+
+    Mainly implement when the API moved from http to https.
+    """
+
     def redirect_request(self, req, fp, code, msg, headers, newurl):
         if code in [301, 302]:
             # We want the posts to work even if we are redirected

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -192,12 +192,11 @@ class Ignore303(HTTPRedirectHandler):
             if code == 301:
                 global SAY
                 if SAY:
-                    o = req.get_full_url()
-                    n = newurl
+                    oldurl = req.get_full_url()
                     print()
                     print("*** ECMWF API has moved")
-                    print("***   OLD: %s" % get_api_url(o))
-                    print("***   NEW: %s" % get_api_url(n))
+                    print("***   OLD: %s" % get_api_url(oldurl))
+                    print("***   NEW: %s" % get_api_url(newurl))
                     print("*** Please update your ~/.ecmwfapirc file")
                     print()
                     SAY = False

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -45,11 +45,7 @@ except ImportError:
     sys.exit(1)
 
 
-###############################################################################
-
 VERSION = "1.6.1"
-
-###############################################################################
 
 
 class APIKeyFetchError(Exception):
@@ -116,9 +112,6 @@ def get_apikey_values():
             )
 
     return key_values
-
-
-###############################################################################
 
 
 class RetryError(Exception):
@@ -252,7 +245,6 @@ class Connection(object):
 
     @robust
     def call(self, url, payload=None, method="GET"):
-
         # Ensure full url
         url = urljoin(self.url, url)
 
@@ -490,7 +482,6 @@ class APIRequest(object):
         return existing_size + bytes_transferred
 
     def execute(self, request, target=None):
-
         status = None
 
         self.connection.submit("%s/%s/requests" % (self.url, self.service), request)
@@ -555,9 +546,6 @@ class APIRequest(object):
             self.log("")
 
 
-###############################################################################
-
-
 class ECMWFDataServer(object):
     def __init__(self, url=None, key=None, email=None, verbose=False, log=None):
         if url is None or key is None or email is None:
@@ -594,9 +582,6 @@ class ECMWFDataServer(object):
             verbose=self.verbose,
         )
         c.execute(req, target)
-
-
-###############################################################################
 
 
 class ECMWFService(object):
@@ -646,5 +631,3 @@ class ECMWFService(object):
         )
         c.execute(req, target)
         self.trace("Done.")
-
-    ###############################################################################

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -591,4 +591,4 @@ class ECMWFService(object):
             quiet=self.quiet,
         )
         c.execute(req, target)
-        self.log("Done.")
+        self.log("Done")

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -379,6 +379,11 @@ def no_log(msg):
     pass
 
 
+def print_with_timestamp(msg):
+    t = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
+    print("%s %s" % (t, msg))
+
+
 class APIRequest(object):
     def __init__(
         self,
@@ -550,7 +555,9 @@ class APIRequest(object):
 
 
 class ECMWFDataServer(object):
-    def __init__(self, url=None, key=None, email=None, verbose=False, log=None):
+    def __init__(
+        self, url=None, key=None, email=None, verbose=False, log=print_with_timestamp
+    ):
         if url is None or key is None or email is None:
             key, url, email = get_apikey_values()
 
@@ -560,19 +567,6 @@ class ECMWFDataServer(object):
         self.verbose = verbose
         self.log = log
 
-    def trace(self, m):
-        if self.log:
-            self.log(m)
-        else:
-            t = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-            print(
-                "%s %s"
-                % (
-                    t,
-                    m,
-                )
-            )
-
     def retrieve(self, req):
         target = req.get("target")
         dataset = req.get("dataset")
@@ -581,7 +575,7 @@ class ECMWFDataServer(object):
             "datasets/%s" % (dataset,),
             self.email,
             self.key,
-            self.trace,
+            self.log,
             verbose=self.verbose,
         )
         c.execute(req, target)
@@ -595,7 +589,7 @@ class ECMWFService(object):
         key=None,
         email=None,
         verbose=False,
-        log=None,
+        log=print_with_timestamp,
         quiet=False,
     ):
         if url is None or key is None or email is None:
@@ -609,28 +603,15 @@ class ECMWFService(object):
         self.quiet = quiet
         self.log = log
 
-    def trace(self, m):
-        if self.log:
-            self.log(m)
-        else:
-            t = time.strftime("%Y-%m-%d %H:%M:%S", time.localtime())
-            print(
-                "%s %s"
-                % (
-                    t,
-                    m,
-                )
-            )
-
     def execute(self, req, target):
         c = APIRequest(
             self.url,
             "services/%s" % (self.service,),
             self.email,
             self.key,
-            self.trace,
+            self.log,
             verbose=self.verbose,
             quiet=self.quiet,
         )
         c.execute(req, target)
-        self.trace("Done.")
+        self.log("Done.")

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -399,10 +399,9 @@ class APIRequest(object):
         self.url = url
         self.service = service
         self.connection = Connection(url, email, key, quiet=quiet, verbose=verbose)
-        self._log = log
+        self.log = log
         self.quiet = quiet
         self.verbose = verbose
-        self._empty_line = False
 
         self.log("ECMWF API python library %s" % (VERSION,))
         self.log("ECMWF API at %s" % (self.url,))
@@ -429,17 +428,6 @@ class APIRequest(object):
                     self.log(n)
             except:
                 pass
-
-    def log(self, m):
-        if m == "":
-            if self._empty_line:
-                return
-            self._log(m)
-            self._empty_line = True
-            return
-
-        self._empty_line = False
-        self._log(m)
 
     def _bytename(self, size):
         prefix = {"": "K", "K": "M", "M": "G", "G": "T", "T": "P", "P": "E"}

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -560,9 +560,9 @@ class ECMWFDataServer(object):
         c = APIRequest(
             self.url,
             "datasets/%s" % (dataset,),
-            self.email,
-            self.key,
-            self.log,
+            email=self.email,
+            key=self.key,
+            log=self.log,
             verbose=self.verbose,
         )
         c.execute(req, target)
@@ -594,9 +594,9 @@ class ECMWFService(object):
         c = APIRequest(
             self.url,
             "services/%s" % (self.service,),
-            self.email,
-            self.key,
-            self.log,
+            email=self.email,
+            key=self.key,
+            log=self.log,
             verbose=self.verbose,
             quiet=self.quiet,
         )


### PR DESCRIPTION
Built on already existing but  broken support in `ecmwfapi.ECMWFDataServer` and `ecmwfapi.ECMWFService` for passing a logging function to be used instead of the default logging function that's using `print`. The functionality was broken in the sense that it didn't apply to all the produced logging messages, and some of the logging messages still used `print`, no matter what.

That means that in order to switch to using Python's `logging` module one could now do something like the following:
```
import logging
from ecmwfapi import ECMWFDataServer

logging.basicConfig(level=logging.INFO)

def my_logging_function(msg):
    logging.info(msg)

server = ECMWFDataServer(log=my_logging_function)
```

Still investigating switching the API to natively use the `logging` module, but that's for another time. I did not want to make any breaking changes, for the time being.
