### PR TITLE
Fail fast when an invalid API access key is provided

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,19 +10,19 @@ Install via pip with:
 
 ## Anonymous access (default, not recommended)
 
-Anonymous access is the default type of access with no configuration needed.
+Anonymous access is the default type of access, with no configuration needed.
 
 However, anonymous access is only available for a limited set of datasets, and comes with a much lower quality of service. For access to all the available datasets, and an improved quality of service, please use registered access (see below).
 
 ## Registered access (recommended)
 
-* Register with ECMWF at https://apps.ecmwf.int/registration/ and then follow the steps below.
-* Login at https://apps.ecmwf.int/auth/login/
-* Retrieve you API access key at https://api.ecmwf.int/v1/key/
+* Register with ECMWF at https://apps.ecmwf.int/registration/.
+* Login at https://apps.ecmwf.int/auth/login/.
+* Retrieve you API access key at https://api.ecmwf.int/v1/key/.
 
-   Note that the key expires in 1 year. You will receive an email to the registered email address 1 month before the expiration date with the renewal instructions. To check the expiry date of your current key log into www.ecmwf.int, and go to https://api.ecmwf.int/v1/key/.
+   Note that the API access key expires in 1 year. You will receive an email to the registered email address 1 month before the expiration date with the renewal instructions. To check the expiry date of your current key, log into www.ecmwf.int, and go to https://api.ecmwf.int/v1/key/.
 
-* Copy the information in this page and paste it in the file $HOME/.ecmwfapirc (Unix/Linux) or %USERPROFILE%\\.ecmwfapirc (Windows: usually in C:\\Users\\\<USERNAME\>\\.ecmwfapirc ; see how to create a file with a leading dot).
+* Copy and paste the information on this page into the file $HOME/.ecmwfapirc (Unix/Linux) or %USERPROFILE%\\.ecmwfapirc (Windows: usually in C:\\Users\\\<USERNAME\>\\.ecmwfapirc).
 
    Your $HOME/.ecmwfapirc (Unix/Linux) or %USERPROFILE%\\.ecmwfapirc (Windows) should look something like this:
    ```
@@ -32,8 +32,7 @@ However, anonymous access is only available for a limited set of datasets, and c
        "email" : "john.smith@example.com"
    }
    ```
-* You can browse the ECMWF data catalogue at https://apps.ecmwf.int/mars-catalogue/
-
+   
 # Example
 
 You can test this small python script to retrieve TIGGE data:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ However, anonymous access is only available for a limited set of datasets, and c
 
    Note that the API access key expires in 1 year. You will receive an email to the registered email address 1 month before the expiration date with the renewal instructions. To check the expiry date of your current key, log into www.ecmwf.int, and go to https://api.ecmwf.int/v1/key/.
 
-* Copy and paste the information on this page into the file $HOME/.ecmwfapirc (Unix/Linux) or %USERPROFILE%\\.ecmwfapirc (Windows: usually in C:\\Users\\\<USERNAME\>\\.ecmwfapirc).
+* Copy and paste the API access key into the file $HOME/.ecmwfapirc (Unix/Linux) or %USERPROFILE%\\.ecmwfapirc (Windows: usually in C:\\Users\\\<USERNAME\>\\.ecmwfapirc).
 
    Your $HOME/.ecmwfapirc (Unix/Linux) or %USERPROFILE%\\.ecmwfapirc (Windows) should look something like this:
    ```
@@ -32,6 +32,8 @@ However, anonymous access is only available for a limited set of datasets, and c
        "email" : "john.smith@example.com"
    }
    ```
+* Alternatively, one can use a file of their own liking, and point to it using environment variable `ECMWF_API_RC_FILE`. `ECMWF_API_RC_FILE` should be set to the full path of the given file. This method takes priority of the previous method of using a .ecmwfapirc file.
+* As yet another option, one can set the API access key values directly in the environment using variables `ECMWF_API_KEY` (key), `ECMWF_API_URL` (url), `ECMWF_API_EMAIL` (email). This method takes priority over the previous method of using environment variable `ECMWF_API_RC_FILE`.
    
 # Example
 

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ However, anonymous access is only available for a limited set of datasets, and c
    
 # Example
 
-You can test this small python script to retrieve TIGGE data:
+You can test this small python script to retrieve TIGGE (https://apps.ecmwf.int/datasets/data/tigge) data. Note that access to TIGGE data requires registered access, and is subject to accepting a licence at https://apps.ecmwf.int/datasets/data/tigge/licence/.
 ```
 #!/usr/bin/env python
 from ecmwfapi import ECMWFDataServer

--- a/README.md
+++ b/README.md
@@ -1,21 +1,26 @@
-ecmwf-api-client
-================
+# ecmwf-api-client
 
-Installation
-============
+# Installation
 
 Install via pip with:
 
 > $ pip install ecmwf-api-client
 
-Configure
-=========
+# Configure
 
-* If you don't have an ECMWF account, please self register at https://apps.ecmwf.int/registration/ and then go to the steps below.
-* Login https://apps.ecmwf.int/auth/login/
-* Retrieve you key at https://api.ecmwf.int/v1/key/
+## Anonymous access (default, not recommended)
 
-Note that the key expires in 1 year. You will receive an email to the registered email address 1 month before the expiration date with the renewal instructions. To check the expiry date of your current key log into www.ecmwf.int, and go to https://api.ecmwf.int/v1/key/.
+Anonymous access is the default type of access with no configuration needed.
+
+However, anonymous access is only available for a limited set of datasets, and comes with a much lower quality of service. For access to all the available datasets, and an improved quality of service, please use registered access (see below).
+
+## Registered access (recommended)
+
+* Register with ECMWF at https://apps.ecmwf.int/registration/ and then follow the steps below.
+* Login at https://apps.ecmwf.int/auth/login/
+* Retrieve you API access key at https://api.ecmwf.int/v1/key/
+
+Note that the API key expires in 1 year. You will receive an email to the registered email address 1 month before the expiration date with the renewal instructions. To check the expiry date of your current key log into www.ecmwf.int, and go to https://api.ecmwf.int/v1/key/.
 
 * Copy the information in this page and paste it in the file $HOME/.ecmwfapirc (Unix/Linux) or %USERPROFILE%\\.ecmwfapirc (Windows: usually in C:\\Users\\\<USERNAME\>\\.ecmwfapirc ; see how to create a file with a leading dot).
 
@@ -29,8 +34,7 @@ Your $HOME/.ecmwfapirc (Unix/Linux) or %USERPROFILE%\\.ecmwfapirc (Windows) shou
 ```
 * You can browse the ECMWF data catalogue at https://apps.ecmwf.int/mars-catalogue/
 
-Example
-=======
+# Example
 
 You can test this small python script to retrieve TIGGE data:
 ```
@@ -59,8 +63,7 @@ server.retrieve({
 })
 ```
 
-Logging
-=======
+# Logging
 
 Logging messages by default are emitted to `stdout` using Python's `print` statement.
 
@@ -78,8 +81,7 @@ def my_logging_function(msg):
 server = ECMWFDataServer(log=my_logging_function)
 ```
 
-License
-=======
+# License
 
 Copyright 2019 European Centre for Medium-Range Weather Forecasts (ECMWF)
 Licensed under the Apache License, Version 2.0 (the “License”); you may not use this file except in compliance with the License. You may obtain a copy of the License at

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -47,6 +47,9 @@ except ImportError:
 VERSION = "1.6.2"
 
 
+DEFAULT_RCFILE_PATH = "~/.ecmwfapirc"
+
+
 class APIKeyNotFoundError(Exception):
     pass
 
@@ -111,7 +114,7 @@ def get_apikey_values():
             return get_apikey_values_from_rcfile(env_rcfile_path)
         else:
             try:
-                return get_apikey_values_from_rcfile("~/.ecmwfapirc")
+                return get_apikey_values_from_rcfile(DEFAULT_RCFILE_PATH)
             except APIKeyNotFoundError:
                 return ("anonymous", "https://api.ecmwf.int/v1", "anonymous@ecmwf.int")
 

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -66,7 +66,7 @@ def get_apikey_values_from_environ():
     )
 
     if not any(apikey_values):
-        raise APIKeyNotFoundError()
+        raise APIKeyNotFoundError("ERROR: No API key found in the environment")
     elif not all(apikey_values):
         raise APIKeyFetchError("ERROR: Incomplete API key found in the environment")
     else:

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -72,14 +72,18 @@ def _get_apikey_from_rcfile():
     except IOError as e:  # Failed reading from file
         raise APIKeyFetchError(str(e))
     except ValueError:  # JSON decoding failed
-        raise APIKeyFetchError("ERROR: Missing or malformed API key in '%s'" % rc_file_path)
+        raise APIKeyFetchError(
+            "ERROR: Missing or malformed API key in '%s'" % rc_file_path
+        )
     except Exception as e:  # Unexpected error
         raise APIKeyFetchError(str(e))
-
-    try:
-        return (api_key["key"], api_key["url"], api_key["email"])
-    except:
-        raise APIKeyFetchError("ERROR: Missing or malformed API key in '%s'" % rc_file_path)
+    else:
+        try:
+            return (api_key["key"], api_key["url"], api_key["email"])
+        except:
+            raise APIKeyFetchError(
+                "ERROR: Missing or malformed API key in '%s'" % rc_file_path
+            )
 
 
 def get_apikey_values():

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -105,7 +105,7 @@ def get_apikey_values_from_rcfile(rcfile_path):
 
 def get_apikey_values():
     """Get the API key values in Python tuple format either directly from the
-    environment, or from a file.  If no API key is found, fall back to anonymous
+    environment, or from a file. If no API key is found, fall back to anonymous
     access.
 
     The complete workflow is the following:

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -53,10 +53,11 @@ class APIKeyFetchError(Exception):
 
 def _get_apikey_from_environ():
     try:
-        key = os.environ["ECMWF_API_KEY"]
-        url = os.environ["ECMWF_API_URL"]
-        email = os.environ["ECMWF_API_EMAIL"]
-        return key, url, email
+        return (
+            os.environ["ECMWF_API_KEY"],
+            os.environ["ECMWF_API_URL"],
+            os.environ["ECMWF_API_EMAIL"],
+        )
     except KeyError:
         raise APIKeyFetchError("ERROR: Could not get the API key from the environment")
 
@@ -78,10 +79,7 @@ def _get_apikey_from_rcfile():
         raise APIKeyFetchError(str(e))
 
     try:
-        key = config["key"]
-        url = config["url"]
-        email = config["email"]
-        return key, url, email
+        return (config["key"], config["url"], config["email"])
     except:
         raise APIKeyFetchError("ERROR: Missing or malformed API key in '%s'" % rc)
 
@@ -100,11 +98,7 @@ def get_apikey_values():
         try:
             key_values = _get_apikey_from_rcfile()
         except APIKeyFetchError:
-            return (
-                "anonymous",
-                "https://api.ecmwf.int/v1",
-                "anonymous@ecmwf.int",
-            )
+            return ("anonymous", "https://api.ecmwf.int/v1", "anonymous@ecmwf.int")
 
     return key_values
 

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -63,25 +63,23 @@ def _get_apikey_from_environ():
 
 
 def _get_apikey_from_rcfile():
-    if "ECMWF_API_RC_FILE" in os.environ:
-        rc = os.path.normpath(os.path.expanduser(os.environ["ECMWF_API_RC_FILE"]))
-    else:
-        rc = os.path.normpath(os.path.expanduser("~/.ecmwfapirc"))
+    rc_file_path = os.environ.get("ECMWF_API_RC_FILE", "~/.ecmwfapirc")
+    absolute_rc_file_path = os.path.normpath(os.path.expanduser(rc_file_path))
 
     try:
-        with open(rc) as f:
-            config = json.load(f)
+        with open(absolute_rc_file_path) as f:
+            api_key = json.load(f)
     except IOError as e:  # Failed reading from file
         raise APIKeyFetchError(str(e))
     except ValueError:  # JSON decoding failed
-        raise APIKeyFetchError("ERROR: Missing or malformed API key in '%s'" % rc)
+        raise APIKeyFetchError("ERROR: Missing or malformed API key in '%s'" % rc_file_path)
     except Exception as e:  # Unexpected error
         raise APIKeyFetchError(str(e))
 
     try:
-        return (config["key"], config["url"], config["email"])
+        return (api_key["key"], api_key["url"], api_key["email"])
     except:
-        raise APIKeyFetchError("ERROR: Missing or malformed API key in '%s'" % rc)
+        raise APIKeyFetchError("ERROR: Missing or malformed API key in '%s'" % rc_file_path)
 
 
 def get_apikey_values():

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -101,9 +101,9 @@ def get_apikey_values():
             key_values = _get_apikey_from_rcfile()
         except APIKeyFetchError:
             return (
-                os.environ.get("ECMWF_API_KEY", "anonymous"),
-                os.environ.get("ECMWF_API_URL", "https://api.ecmwf.int/v1"),
-                os.environ.get("ECMWF_API_EMAIL", "anonymous@ecmwf.int"),
+                "anonymous",
+                "https://api.ecmwf.int/v1",
+                "anonymous@ecmwf.int",
             )
 
     return key_values

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -63,17 +63,17 @@ def get_apikey_values_from_environ():
 
 
 def get_apikey_values_from_rcfile():
-    rc_file_path = os.environ.get("ECMWF_API_RC_FILE", "~/.ecmwfapirc")
-    absolute_rc_file_path = os.path.normpath(os.path.expanduser(rc_file_path))
+    rcfile_path = os.environ.get("ECMWF_API_RC_FILE", "~/.ecmwfapirc")
+    absolute_rcfile_path = os.path.normpath(os.path.expanduser(rcfile_path))
 
     try:
-        with open(absolute_rc_file_path) as f:
+        with open(absolute_rcfile_path) as f:
             api_key = json.load(f)
     except IOError as e:  # Failed reading from file
         raise APIKeyFetchError(str(e))
     except ValueError:  # JSON decoding failed
         raise APIKeyFetchError(
-            "ERROR: Missing or malformed API key in '%s'" % rc_file_path
+            "ERROR: Missing or malformed API key in '%s'" % rcfile_path
         )
     except Exception as e:  # Unexpected error
         raise APIKeyFetchError(str(e))
@@ -82,7 +82,7 @@ def get_apikey_values_from_rcfile():
             return (api_key["key"], api_key["url"], api_key["email"])
         except:
             raise APIKeyFetchError(
-                "ERROR: Missing or malformed API key in '%s'" % rc_file_path
+                "ERROR: Missing or malformed API key in '%s'" % rcfile_path
             )
 
 

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -51,7 +51,7 @@ class APIKeyFetchError(Exception):
     pass
 
 
-def _get_apikey_from_environ():
+def get_apikey_values_from_environ():
     try:
         return (
             os.environ["ECMWF_API_KEY"],
@@ -62,7 +62,7 @@ def _get_apikey_from_environ():
         raise APIKeyFetchError("ERROR: Could not get the API key from the environment")
 
 
-def _get_apikey_from_rcfile():
+def get_apikey_values_from_rcfile():
     rc_file_path = os.environ.get("ECMWF_API_RC_FILE", "~/.ecmwfapirc")
     absolute_rc_file_path = os.path.normpath(os.path.expanduser(rc_file_path))
 
@@ -95,10 +95,10 @@ def get_apikey_values():
         Tuple with the API key token, url, and email.
     """
     try:
-        return _get_apikey_from_environ()
+        return get_apikey_values_from_environ()
     except APIKeyFetchError:
         try:
-            return _get_apikey_from_rcfile()
+            return get_apikey_values_from_rcfile()
         except APIKeyFetchError:
             return ("anonymous", "https://api.ecmwf.int/v1", "anonymous@ecmwf.int")
 

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -108,11 +108,37 @@ def get_apikey_values():
 
     If no API key is found, fall back to anonymous access.
 
+    The complete workflow is the following:
+
+    - Step 1: the environment is checked for variables ECMWF_API_KEY,
+        ECMWF_API_URL, ECMWF_API_EMAIL.
+        * If all found, and not empty, return their values in Python tuple
+            format. 
+        * If only some found, and not empty, assume an incomplete API key, and
+            raise APIKeyFetchError.
+        * If none found, or found but empty, assume no API key available in the
+            environment, and continue to the next step.
+    - Step 2: the environment is checked for variable ECMWF_API_RC_FILE, meant
+        to point to a user defined API key file.
+        * If found, but pointing to a file not found, raise APIKeyNotFoundError.
+        * If found, and the file it points to exists, but cannot not be read, or
+            contains an invalid API key, raise APIKeyFetchError.
+        * If found, and the file it points to exists, can be read, and contains
+            a valid API key, return the API key in Python tuple format.
+        * If not found, or empty, assume no user provided API key file and
+            continue to the next step.
+    - Step 3: try the default ~/.ecmwfapirc file.
+        * Same as step 2, except for when ~/.ecmwfapirc is not found, where we
+            continue to the next step.
+    - Step 4: No API key found, so fall back to anonymous access.
+
     Returns:
-        Tuple with the API key token, url, and email.
+        Pyhon tuple with the API key token, url, and email.
 
     Raises:
         APIKeyFetchError: If an API key is found, but invalid.
+        APIKeyNotFound: When ECMWF_API_RC_FILE is defined, but pointing to a
+            file that does not exist.
     """
     try:
         return get_apikey_values_from_environ()

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -104,12 +104,15 @@ def get_apikey_values_from_rcfile(rcfile_path):
 
 
 def get_apikey_values():
-    """Get the API key from either the environment or the '.ecmwfapirc' file,
-    in this order. If the API key is not available or invalid, use the API key
-    for anonymous access as a fallback.
+    """Get the API key either directly from the environment, or from a file.
+
+    If no API key is found, fall back to anonymous access.
 
     Returns:
         Tuple with the API key token, url, and email.
+
+    Raises:
+        APIKeyFetchError: If an API key is found, but invalid.
     """
     try:
         return get_apikey_values_from_environ()

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -104,9 +104,9 @@ def get_apikey_values_from_rcfile(rcfile_path):
 
 
 def get_apikey_values():
-    """Get the API key either directly from the environment, or from a file.
-
-    If no API key is found, fall back to anonymous access.
+    """Get the API key values in Python tuple format either directly from the
+    environment, or from a file.  If no API key is found, fall back to anonymous
+    access.
 
     The complete workflow is the following:
 
@@ -118,6 +118,7 @@ def get_apikey_values():
             raise APIKeyFetchError.
         * If none found, or found but empty, assume no API key available in the
             environment, and continue to the next step.
+
     - Step 2: the environment is checked for variable ECMWF_API_RC_FILE, meant
         to point to a user defined API key file.
         * If found, but pointing to a file not found, raise APIKeyNotFoundError.
@@ -127,9 +128,11 @@ def get_apikey_values():
             a valid API key, return the API key in Python tuple format.
         * If not found, or empty, assume no user provided API key file and
             continue to the next step.
+
     - Step 3: try the default ~/.ecmwfapirc file.
         * Same as step 2, except for when ~/.ecmwfapirc is not found, where we
             continue to the next step.
+
     - Step 4: No API key found, so fall back to anonymous access.
 
     Returns:

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -59,18 +59,18 @@ class APIKeyFetchError(Exception):
 
 
 def get_apikey_values_from_environ():
-    api_key_values = (
+    apikey_values = (
         os.getenv("ECMWF_API_KEY"),
         os.getenv("ECMWF_API_URL"),
         os.getenv("ECMWF_API_EMAIL"),
     )
 
-    if not any(api_key_values):
+    if not any(apikey_values):
         raise APIKeyNotFoundError()
-    elif not all(api_key_values):
+    elif not all(apikey_values):
         raise APIKeyFetchError("ERROR: Incomplete API key found in the environment")
     else:
-        return api_key_values
+        return apikey_values
 
 
 def get_apikey_values_from_rcfile(rcfile_path):
@@ -78,7 +78,7 @@ def get_apikey_values_from_rcfile(rcfile_path):
 
     try:
         with open(rcfile_path) as f:
-            api_key = json.load(f)
+            apikey = json.load(f)
     except FileNotFoundError as e:
         raise APIKeyNotFoundError(str(e))
     except IOError as e:  # Failed reading from file
@@ -91,7 +91,7 @@ def get_apikey_values_from_rcfile(rcfile_path):
         raise APIKeyFetchError(str(e))
     else:
         try:
-            return (api_key["key"], api_key["url"], api_key["email"])
+            return (apikey["key"], apikey["url"], apikey["email"])
         except:
             raise APIKeyFetchError(
                 "ERROR: Missing or malformed API key in '%s'" % rcfile_path

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -48,6 +48,11 @@ VERSION = "1.6.2"
 
 
 DEFAULT_RCFILE_PATH = "~/.ecmwfapirc"
+ANONYMOUS_APIKEY_VALUES = (
+    "anonymous",
+    "https://api.ecmwf.int/v1",
+    "anonymous@ecmwf.int",
+)
 
 
 class APIKeyNotFoundError(Exception):
@@ -116,7 +121,7 @@ def get_apikey_values():
             try:
                 return get_apikey_values_from_rcfile(DEFAULT_RCFILE_PATH)
             except APIKeyNotFoundError:
-                return ("anonymous", "https://api.ecmwf.int/v1", "anonymous@ecmwf.int")
+                return ANONYMOUS_APIKEY_VALUES
 
 
 class RetryError(Exception):

--- a/ecmwfapi/api.py
+++ b/ecmwfapi/api.py
@@ -95,14 +95,12 @@ def get_apikey_values():
         Tuple with the API key token, url, and email.
     """
     try:
-        key_values = _get_apikey_from_environ()
+        return _get_apikey_from_environ()
     except APIKeyFetchError:
         try:
-            key_values = _get_apikey_from_rcfile()
+            return _get_apikey_from_rcfile()
         except APIKeyFetchError:
             return ("anonymous", "https://api.ecmwf.int/v1", "anonymous@ecmwf.int")
-
-    return key_values
 
 
 class RetryError(Exception):


### PR DESCRIPTION
Compared to the existing implementation where we fail silently and fall back to the next available method of providing an API access key, ultimately ending up using anonymous access.